### PR TITLE
update dgc-spn paper details and add reference to libspn-keras code

### DIFF
--- a/_pages/code.md
+++ b/_pages/code.md
@@ -9,6 +9,7 @@ order: 5
 
 - [**Juice.jl**](https://github.com/Juice-jl/ProbabilisticCircuits.jl) a `Julia` package for logical and probabilistic circuits with fast `CUDA` bindings 
 - [**SPFlow**](https://github.com/SPFlow/SPFlow) an easy and extensible `python` library for <a href="models#spns">SPNs</a> compiling them to `pytorch`, `tensorflows` and `C` code
+- [**LibSPN-Keras**](https://github.com/pronobis/libspn-keras) Keras-centered TensorFlow 2.x compatible library for <a href="models#spns">SPNs</a>
 - [**LibSPN**](http://www.libspn.org/) tensorflow implementation of <a href="models#spns">SPNs</a> with bindings in `python`
 - [**Libra Toolkit**](http://libra.cs.uoregon.edu/) Learning and inference routines
      for <a href="models#acs">ACs</a> implemented in `Ocaml`

--- a/_papers/vandewolfshaar2019deep.md
+++ b/_papers/vandewolfshaar2019deep.md
@@ -1,7 +1,7 @@
 ---
 layout: paper
 ref: "vandewolfshaar2019deep"
-title:  "Deep Generalized Convolutional Sum-Product Networks for Probabilistic Image Representations"
+title:  "Deep Generalized Convolutional Sum-Product Networks"
 date:   2019-01-3 00:00
 tags: spns par-le cv
 image: ""


### PR DESCRIPTION
Hi!

First of all, thank you for creating yet another amazing repo with a thorough overview on PCs. I have a few changes related to the work I've done on Deep Generalized Convolutional SPNs and `libspn-keras`.

Changes are:
- Add mention of `libspn-keras`
- Update paper details for `vandewolfshaar2019deep.md`